### PR TITLE
Retain ordering groups and controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,12 +37,13 @@
     "typescript": "^2.8.1"
   },
   "dependencies": {
+    "azure-devops-node-api": "^6.5.0",
     "guid-typescript": "^1.0.7",
     "jsonc-parser": "^2.0.0",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
+    "os": "^0.1.1",
     "url": "^0.11.0",
-    "azure-devops-node-api": "^6.5.0",
     "vss-web-extension-sdk": "^5.131.0"
   }
 }

--- a/src/Common/Constants.ts
+++ b/src/Common/Constants.ts
@@ -1,8 +1,12 @@
+import * as os from 'os';
+
+let separator = os.platform() === "win32" ? "\\" : "/";
+
 export const PICKLIST_NO_ACTION = "PICKLIST_NO_ACTION";
 export const defaultEncoding = "utf-8";
 export const defaultConfigurationFilename = "configuration.json";
-export const defaultLogFileName = "output\\processMigrator.log";
-export const defaultProcessFilename = "output\\process.json";
+export const defaultLogFileName = "output" + separator + "processMigrator.log";
+export const defaultProcessFilename = "output" + separator + "process.json";
 export const paramMode = "mode";
 export const paramConfig = "config";
 export const paramSourceToken = "sourceToken";

--- a/src/Common/ProcessImporter.ts
+++ b/src/Common/ProcessImporter.ts
@@ -249,9 +249,10 @@ export class ProcessImporter {
     ) {
         logger.logVerbose(`Start import inherited group changes`);
         for (const section of page.sections) {
-            for (const group of section.groups) {
+            for (let groupIndex = 0; groupIndex < section.groups.length; groupIndex++) {
+                let group = section.groups[groupIndex];
                 if (group.inherited && group.overridden) {
-                    const updatedGroup: WITProcessDefinitionsInterfaces.Group = Utility.toCreateGroup(group);
+                    const updatedGroup: WITProcessDefinitionsInterfaces.Group = Utility.toCreateGroup(group, groupIndex);
                     await this._editGroup(updatedGroup, page, section, group, witLayout, payload);
                 }
             }
@@ -265,7 +266,8 @@ export class ProcessImporter {
     ) {
         logger.logVerbose(`Start import custom groups and all controls`);
         for (const section of page.sections) {
-            for (const group of section.groups) {
+            for (let groupIndex = 0; groupIndex < section.groups.length; groupIndex++) {
+                let group = section.groups[groupIndex];
                 let newGroup: WITProcessDefinitionsInterfaces.Group;
 
                 if (group.isContribution === true && this._config.options.skipImportFormContributions === true) {
@@ -303,7 +305,7 @@ export class ProcessImporter {
                     }
                     else {
                         // special handling for HTML control - we must create a group containing the HTML control at same time.
-                        const createGroup: WITProcessDefinitionsInterfaces.Group = Utility.toCreateGroup(group);
+                        const createGroup: WITProcessDefinitionsInterfaces.Group = Utility.toCreateGroup(group, groupIndex);
                         createGroup.controls = group.controls;
                         await this._createGroup(createGroup, page, section, witLayout, payload);
                     }
@@ -313,17 +315,17 @@ export class ProcessImporter {
 
                     if (!group.inherited) {
                         //create the group if it's not inherited
-                        const createGroup = Utility.toCreateGroup(group);
+                        const createGroup = Utility.toCreateGroup(group, groupIndex);
                         newGroup = await this._createGroup(createGroup, page, section, witLayout, payload);
                         group.id = newGroup.id;
                     }
 
-                    for (let i = 0; i < group.controls.length; i++) {
-                        let control = group.controls[i];
+                    for (let controlIndex = 0; controlIndex < group.controls.length; controlIndex++) {
+                        let control = group.controls[controlIndex];
 
                         if (!control.inherited || control.overridden) {
                             try {
-                                let createControl: WITProcessDefinitionsInterfaces.Control = Utility.toCreateControl(control, i);
+                                let createControl: WITProcessDefinitionsInterfaces.Control = Utility.toCreateControl(control, controlIndex);
 
                                 if (control.controlType === "WebpageControl" || (control.isContribution === true && this._config.options.skipImportFormContributions === true)) {
                                     // Skip web page control for now since not supported in inherited process.

--- a/src/Common/ProcessImporter.ts
+++ b/src/Common/ProcessImporter.ts
@@ -318,10 +318,12 @@ export class ProcessImporter {
                         group.id = newGroup.id;
                     }
 
-                    for (const control of group.controls) {
+                    for (let i = 0; i < group.controls.length; i++) {
+                        let control = group.controls[i];
+
                         if (!control.inherited || control.overridden) {
                             try {
-                                let createControl: WITProcessDefinitionsInterfaces.Control = Utility.toCreateControl(control);
+                                let createControl: WITProcessDefinitionsInterfaces.Control = Utility.toCreateControl(control, i);
 
                                 if (control.controlType === "WebpageControl" || (control.isContribution === true && this._config.options.skipImportFormContributions === true)) {
                                     // Skip web page control for now since not supported in inherited process.

--- a/src/Common/Utilities.ts
+++ b/src/Common/Utilities.ts
@@ -66,7 +66,7 @@ export class Utility {
     /**Convert group from getLayout group interface to WITProcessDefinitionsInterfaces.Group
      * @param group
     */
-    public static toCreateGroup(group: WITProcessDefinitionsInterfaces.Group): WITProcessDefinitionsInterfaces.Group {
+    public static toCreateGroup(group: WITProcessDefinitionsInterfaces.Group, order: number): WITProcessDefinitionsInterfaces.Group {
         let createGroup: WITProcessDefinitionsInterfaces.Group = {
             id: group.id,
             inherited: group.inherited,
@@ -76,7 +76,7 @@ export class Utility {
             controls: null,
             contribution: group.contribution,
             height: group.height,
-            order: null,
+            order: order,
             overridden: null
         }
         return createGroup;

--- a/src/Common/Utilities.ts
+++ b/src/Common/Utilities.ts
@@ -85,7 +85,7 @@ export class Utility {
     /**Convert control from getLayout control interface to WITProcessDefinitionsInterfaces.Control
      * @param control
     */
-    public static toCreateControl(control: WITProcessDefinitionsInterfaces.Control): WITProcessDefinitionsInterfaces.Control {
+    public static toCreateControl(control: WITProcessDefinitionsInterfaces.Control, order: number): WITProcessDefinitionsInterfaces.Control {
         let createControl: WITProcessDefinitionsInterfaces.Control = {
             id: control.id,
             inherited: control.inherited,
@@ -98,7 +98,7 @@ export class Utility {
             isContribution: control.isContribution,
             contribution: control.contribution,
             height: control.height,
-            order: null,
+            order: order,
             overridden: null
         }
         return createControl;


### PR DESCRIPTION
When running the migration for processes with both inherited and custom groups and fields, the order isn't retained so that custom fields are always last. This PR will keep the order of the fields and groups so that they are the same when migrating processes.