### PR TITLE
Restore support for OverwriteProcessOnTarget command line arg

### DIFF
--- a/src/NodeJs/ConfigurationProcessor.ts
+++ b/src/NodeJs/ConfigurationProcessor.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from "fs";
 import { normalize, join, resolve } from "path";
 import * as minimist from "minimist";
 import * as url from "url";
-import { defaultConfiguration, defaultConfigurationFilename, defaultEncoding, paramConfig, paramMode, paramSourceToken, paramTargetToken } from "../common/Constants";
+import { defaultConfiguration, defaultConfigurationFilename, defaultEncoding, paramConfig, paramMode, paramSourceToken, paramTargetToken, paramOverwriteProcessOnTarget } from "../common/Constants";
 import { IConfigurationFile, LogLevel, Modes, ICommandLineOptions } from "../common/Interfaces";
 import { logger } from "../common/Logger";
 import { Utility } from "../common/Utilities";
@@ -46,6 +46,7 @@ export function ProcesCommandLine(): ICommandLineOptions {
     ret[paramConfig] = configFileName;
     ret[paramSourceToken] = parsedArgs[paramSourceToken];
     ret[paramTargetToken] = parsedArgs[paramTargetToken];
+    ret[paramOverwriteProcessOnTarget] = parsedArgs[paramOverwriteProcessOnTarget];
 
     return <ICommandLineOptions>ret;
 }

--- a/src/NodeJs/ConfigurationProcessor.ts
+++ b/src/NodeJs/ConfigurationProcessor.ts
@@ -63,10 +63,11 @@ export async function ProcessConfigurationFile(commandLineOptions: ICommandLineO
         process.exit(1);
     }
 
-    const configuration = jsoncParse(readFileSync(configFile, defaultEncoding)) as IConfigurationFile;
+    const rawFile = readFileSync(configFile, defaultEncoding);
+    const configuration = jsoncParse(rawFile) as IConfigurationFile;
 
     // replace token if overriden from command line
-    logger.logInfo(`Loaded configuration from ${resolve(join(process.cwd(), configFile))}: \r\n${JSON.stringify(configuration, null, 4)}`);
+    logger.logInfo(`Loaded configuration from ${resolve(join(process.cwd(), configFile))}: \r\n${rawFile}`);
     configuration.sourceAccountToken = commandLineOptions.sourceToken ? commandLineOptions.sourceToken : configuration.sourceAccountToken;
     configuration.targetAccountToken = commandLineOptions.targetToken ? commandLineOptions.targetToken : configuration.targetAccountToken;
 

--- a/src/NodeJs/ConfigurationProcessor.ts
+++ b/src/NodeJs/ConfigurationProcessor.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, writeFileSync } from "fs";
-import { normalize, join, resolve } from "path";
+import { normalize } from "path";
 import * as minimist from "minimist";
 import * as url from "url";
 import { defaultConfiguration, defaultConfigurationFilename, defaultEncoding, paramConfig, paramMode, paramSourceToken, paramTargetToken, paramOverwriteProcessOnTarget } from "../common/Constants";

--- a/src/NodeJs/ConfigurationProcessor.ts
+++ b/src/NodeJs/ConfigurationProcessor.ts
@@ -46,11 +46,10 @@ export function ProcesCommandLine(): ICommandLineOptions {
     ret[paramConfig] = configFileName;
     ret[paramSourceToken] = parsedArgs[paramSourceToken];
     ret[paramTargetToken] = parsedArgs[paramTargetToken];
-    ret[paramOverwriteProcessOnTarget] = parsedArgs[paramOverwriteProcessOnTarget];
+    ret[paramOverwriteProcessOnTarget] = !!parsedArgs[paramOverwriteProcessOnTarget];
 
     return <ICommandLineOptions>ret;
 }
-
 export async function ProcessConfigurationFile(commandLineOptions: ICommandLineOptions): Promise<IConfigurationFile> {
     // Load configuration file
     const configFile = commandLineOptions.config;
@@ -64,11 +63,9 @@ export async function ProcessConfigurationFile(commandLineOptions: ICommandLineO
         process.exit(1);
     }
 
-    const rawFile = readFileSync(configFile, defaultEncoding);
-    const configuration = jsoncParse(rawFile) as IConfigurationFile;
+    const configuration = jsoncParse(readFileSync(configFile, defaultEncoding)) as IConfigurationFile;
 
     // replace token if overriden from command line
-    logger.logInfo(`Loaded configuration from ${resolve(join(process.cwd(), configFile))}: \r\n${rawFile}`);
     configuration.sourceAccountToken = commandLineOptions.sourceToken ? commandLineOptions.sourceToken : configuration.sourceAccountToken;
     configuration.targetAccountToken = commandLineOptions.targetToken ? commandLineOptions.targetToken : configuration.targetAccountToken;
 

--- a/src/NodeJs/ConfigurationProcessor.ts
+++ b/src/NodeJs/ConfigurationProcessor.ts
@@ -66,6 +66,7 @@ export async function ProcessConfigurationFile(commandLineOptions: ICommandLineO
     const configuration = jsoncParse(readFileSync(configFile, defaultEncoding)) as IConfigurationFile;
 
     // replace token if overriden from command line
+    logger.logInfo(`Loaded configuration from ${configFile}: \r\n${JSON.stringify(configuration, null, 4)}`);
     configuration.sourceAccountToken = commandLineOptions.sourceToken ? commandLineOptions.sourceToken : configuration.sourceAccountToken;
     configuration.targetAccountToken = commandLineOptions.targetToken ? commandLineOptions.targetToken : configuration.targetAccountToken;
 

--- a/src/NodeJs/ConfigurationProcessor.ts
+++ b/src/NodeJs/ConfigurationProcessor.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, writeFileSync } from "fs";
-import { normalize } from "path";
+import { normalize, join, resolve } from "path";
 import * as minimist from "minimist";
 import * as url from "url";
 import { defaultConfiguration, defaultConfigurationFilename, defaultEncoding, paramConfig, paramMode, paramSourceToken, paramTargetToken } from "../common/Constants";
@@ -66,7 +66,7 @@ export async function ProcessConfigurationFile(commandLineOptions: ICommandLineO
     const configuration = jsoncParse(readFileSync(configFile, defaultEncoding)) as IConfigurationFile;
 
     // replace token if overriden from command line
-    logger.logInfo(`Loaded configuration from ${configFile}: \r\n${JSON.stringify(configuration, null, 4)}`);
+    logger.logInfo(`Loaded configuration from ${resolve(join(process.cwd(), configFile))}: \r\n${JSON.stringify(configuration, null, 4)}`);
     configuration.sourceAccountToken = commandLineOptions.sourceToken ? commandLineOptions.sourceToken : configuration.sourceAccountToken;
     configuration.targetAccountToken = commandLineOptions.targetToken ? commandLineOptions.targetToken : configuration.targetAccountToken;
 

--- a/src/NodeJs/ConfigurationProcessor.ts
+++ b/src/NodeJs/ConfigurationProcessor.ts
@@ -50,6 +50,7 @@ export function ProcesCommandLine(): ICommandLineOptions {
 
     return <ICommandLineOptions>ret;
 }
+
 export async function ProcessConfigurationFile(commandLineOptions: ICommandLineOptions): Promise<IConfigurationFile> {
     // Load configuration file
     const configFile = commandLineOptions.config;


### PR DESCRIPTION
I've found I cannot update my existing process on target because `OverwriteProcessOnTarget` is never parsed from the command line args. 