### PR TITLE
Adding PAT note to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ NOTE: This only works with 'Inherited Process', for 'XML process' you may upload
    Just run ```process-migrator``` without any argument will create the file if it does not exist.
 
    ##### ![](https://imgplaceholder.com/100x17/cccccc/fe2904?text=WARNING&font-size=15) CONFIGURATION FILE HAS PAT, RIGHT PROTECT IT !
-- Run `process-migrator [--mode=<migrate(default)/import/export> [--config=<your-configuration-file-path>]`
+- Run `process-migrator [--mode=<migrate(default)/import/export>] [--config=<your-configuration-file-path>]`
   
 ## Contribute
 
@@ -54,3 +54,4 @@ NOTE: This only works with 'Inherited Process', for 'XML process' you may upload
 - If identities used in field default value or rules are not available in target account, import WILL fail
    1) For rules you may use 'continueOnRuleImportFailure' option to proceed with rest of import when such error is occurred.
    2) For identity field default value, you may use 'continueOnFieldDefaultValueFailure' option to proceed with rest of import when such error is occurred.
+- Personal Access Token (PAT) needs to be scoped to allow "Read, write, & manage" access for "Work Items"

--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ NOTE: This only works with 'Inherited Process', for 'XML process' you may upload
    1) For rules you may use 'continueOnRuleImportFailure' option to proceed with rest of import when such error is occurred.
    2) For identity field default value, you may use 'continueOnFieldDefaultValueFailure' option to proceed with rest of import when such error is occurred.
 - Personal Access Token (PAT) needs to allow "Read, write, & manage" access for the "Work Items" scope.
+   1) The tool needs to be able to modify the definition of work items and work item types (to add custom fields for example).

--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ NOTE: This only works with 'Inherited Process', for 'XML process' you may upload
 - If identities used in field default value or rules are not available in target account, import WILL fail
    1) For rules you may use 'continueOnRuleImportFailure' option to proceed with rest of import when such error is occurred.
    2) For identity field default value, you may use 'continueOnFieldDefaultValueFailure' option to proceed with rest of import when such error is occurred.
-- Personal Access Token (PAT) needs to be scoped to allow "Read, write, & manage" access for "Work Items"
+- Personal Access Token (PAT) needs to allow "Read, write, & manage" access for "Work Items" scope.

--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ NOTE: This only works with 'Inherited Process', for 'XML process' you may upload
 - If identities used in field default value or rules are not available in target account, import WILL fail
    1) For rules you may use 'continueOnRuleImportFailure' option to proceed with rest of import when such error is occurred.
    2) For identity field default value, you may use 'continueOnFieldDefaultValueFailure' option to proceed with rest of import when such error is occurred.
-- Personal Access Token (PAT) needs to allow "Read, write, & manage" access for "Work Items" scope.
+- Personal Access Token (PAT) needs to allow "Read, write, & manage" access for the "Work Items" scope.


### PR DESCRIPTION
Changes:
- Added a note to the readme clarifying the required scope and access for the configuration.json PATs
- Added a missing bracket in the run instructions 