### PR TITLE
Fix issue where files are referenced using wrong case

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
             "type": "node",
             "request": "launch",
             "name": "Launch process migrate",
-            "program": "${workspaceFolder}/build/nodejs/nodejs/main.js",
+            "program": "${workspaceFolder}/build/nodejs/nodejs/Main.js",
             "sourceMaps": true,
             "args": [
             ]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To run this tool you must have both NodeJS and NPM installed. They are available
 
 - From the root of source, run `npm install`
 - Build by `npm run build`
-- Execute through `node build\nodejs\nodejs\main.js <args>`
+- Execute through `node build\nodejs\nodejs\Main.js <args>`
 
 ## Documentation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "vss-web-extension-sdk": "5.141.0"
       },
       "bin": {
-        "process-migrator": "build/nodejs/nodejs/main.js"
+        "process-migrator": "build/nodejs/nodejs/Main.js"
       },
       "devDependencies": {
         "@types/minimist": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Proces import/export Node.js application",
   "main": "",
   "bin": {
-    "process-migrator": "build/nodejs/nodejs/main.js"
+    "process-migrator": "build/nodejs/nodejs/Main.js"
   },
   "engines": {
     "node": ">=8.11.2"


### PR DESCRIPTION
On case sensitive file systems the reference to the main program (Main.js script) is incorrectly cased, causing the package not to load.