### PR TITLE
fix: use npm proxy registry for package resolution

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://packagefeedproxy.microsoft.io/npm/

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
     },
     "node_modules/@types/jquery": {
       "version": "3.5.16",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.16.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/jquery/-/jquery-3.5.16.tgz",
       "integrity": "sha512-bsI7y4ZgeMkmpG9OM710RRzDFp+w4P1RGiIt30C1mSBT+ExCleeh4HObwgArnDFELmRrOpXgSYN9VF1hj+f1lw==",
       "dependencies": {
         "@types/sizzle": "*"
@@ -40,7 +40,7 @@
     },
     "node_modules/@types/jqueryui": {
       "version": "1.12.16",
-      "resolved": "https://registry.npmjs.org/@types/jqueryui/-/jqueryui-1.12.16.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/jqueryui/-/jqueryui-1.12.16.tgz",
       "integrity": "sha512-6huAQDpNlso9ayaUT9amBOA3kj02OCeUWs+UvDmbaJmwkHSg/HLsQOoap/D5uveN9ePwl72N45Bl+Frp5xyG1Q==",
       "dependencies": {
         "@types/jquery": "*"
@@ -48,18 +48,18 @@
     },
     "node_modules/@types/knockout": {
       "version": "3.4.72",
-      "resolved": "https://registry.npmjs.org/@types/knockout/-/knockout-3.4.72.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/knockout/-/knockout-3.4.72.tgz",
       "integrity": "sha512-L/dGG0DdadKj0nsumdvkNonEcHMRe4RflgHEoHFzj1RZ+xuUMayF7+4Jj5pALOD462M/x4cGa9GuadBDiU6nRw=="
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
     },
     "node_modules/@types/mkdirp": {
       "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/mkdirp/-/mkdirp-0.5.2.tgz",
       "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
       "dev": true,
       "dependencies": {
@@ -68,38 +68,38 @@
     },
     "node_modules/@types/mousetrap": {
       "version": "1.5.34",
-      "resolved": "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.5.34.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/mousetrap/-/mousetrap-1.5.34.tgz",
       "integrity": "sha512-a2yhRIADupQfOFM75v7GfcQQLUxU705+i/xcZ3N/3PK3Xdo31SUfuCUByWPGOHB1e38m7MxTx/D8FPVsJXZKJw=="
     },
     "node_modules/@types/node": {
       "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/node/-/node-8.10.0.tgz",
       "integrity": "sha512-7IGHZQfRfa0bCd7zUBVUGFKFn31SpaLDFfNoCAqkTGQO5JlHC9BwQA/CG9KZlABFxIUtXznyFgechjPQEGrUTg==",
       "dev": true
     },
     "node_modules/@types/q": {
       "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/q/-/q-0.0.32.tgz",
       "integrity": "sha512-qYi3YV9inU/REEfxwVcGZzbS3KG/Xs90lv0Pr+lDtuVjBPGd1A+eciXzVSaRvLify132BfcvhvEjeVahrUl0Ug=="
     },
     "node_modules/@types/react": {
       "version": "15.7.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-15.7.12.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/react/-/react-15.7.12.tgz",
       "integrity": "sha512-FbIDKxGEzmf0jM+1ArXAJwJzg7GkUq5nLVBIz/PSBwVUzATuAjbPrN+UUEAW6zpt/A2WF8XMfSKsNfGX95xCsQ=="
     },
     "node_modules/@types/requirejs": {
       "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/@types/requirejs/-/requirejs-2.1.34.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/requirejs/-/requirejs-2.1.34.tgz",
       "integrity": "sha512-iQLGNE1DyIRYih60B47l/hI5X7J0wAnnRBL6Yn85GUYQg8Fm3wl8kvT6NRwncKroUOSx7/lbAagIFNV7y02DiQ=="
     },
     "node_modules/@types/sizzle": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/sizzle/-/sizzle-2.3.3.tgz",
       "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
     },
     "node_modules/azure-devops-node-api": {
       "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-6.6.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/azure-devops-node-api/-/azure-devops-node-api-6.6.3.tgz",
       "integrity": "sha512-94wSu4O6CSSXoqYWg7Rzt2/IqbW2xVNu2qOtx6e7lnXxnDOcAu4eRzi8tgVNHsXTIGOVEsTqgMvGvFThKr9Pig==",
       "dependencies": {
         "os": "0.1.1",
@@ -110,17 +110,17 @@
     },
     "node_modules/guid-typescript": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/guid-typescript/-/guid-typescript-1.0.9.tgz",
       "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="
     },
     "node_modules/jsonc-parser": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
       "integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg=="
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -128,7 +128,7 @@
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -139,17 +139,17 @@
     },
     "node_modules/os": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/os/-/os-0.1.1.tgz",
       "integrity": "sha512-jg06S2xr5De63mLjZVJDf3/k37tpjppr2LR7MUOsxv8XuUCVpCnvbCksXCBcB5gQqQf/K0+87WGTRlAj5q7r1A=="
     },
     "node_modules/punycode": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
     },
     "node_modules/querystring": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
       "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "engines": {
@@ -158,7 +158,7 @@
     },
     "node_modules/tunnel": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/tunnel/-/tunnel-0.0.4.tgz",
       "integrity": "sha512-o9QYRJN5WgS8oCtqvwzzcfnzaTnDPr7HpUsQdSXscTyzXbjvl4wSHPTUKOKzEaDeQvOuyRtt3ui+ujM7x7TReQ==",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -166,7 +166,7 @@
     },
     "node_modules/typed-rest-client": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.0.9.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/typed-rest-client/-/typed-rest-client-1.0.9.tgz",
       "integrity": "sha512-iOdwgmnP/tF6Qs+oY4iEtCf/3fnCDl7Gy9LGPJ4E3M4Wj3uaSko15FVwbsaBmnBqTJORnXBWVY5306D4HH8oiA==",
       "dependencies": {
         "tunnel": "0.0.4",
@@ -175,7 +175,7 @@
     },
     "node_modules/typescript": {
       "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/typescript/-/typescript-2.9.2.tgz",
       "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
       "dev": true,
       "bin": {
@@ -188,12 +188,12 @@
     },
     "node_modules/underscore": {
       "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha512-5WsVTFcH1ut/kkhAaHf4PVgI8c7++GiVcpCGxPouI6ZVjsqPnSDf8h/8HtVqc0t4fzRXwnMK70EcZeAs3PIddg=="
     },
     "node_modules/url": {
       "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/url/-/url-0.11.0.tgz",
       "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
       "dependencies": {
         "punycode": "1.3.2",
@@ -202,7 +202,7 @@
     },
     "node_modules/vss-web-extension-sdk": {
       "version": "5.141.0",
-      "resolved": "https://registry.npmjs.org/vss-web-extension-sdk/-/vss-web-extension-sdk-5.141.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/vss-web-extension-sdk/-/vss-web-extension-sdk-5.141.0.tgz",
       "integrity": "sha512-c/r/HWQh4hljKOSNQMiFoeICckKFfU/1nxDCVFhioDHOE8B0i5aJN9rrihGilgMXugzl8K5hBsZs42eFqd30AQ==",
       "deprecated": "Package no longer supported. Please use https://www.npmjs.com/package/azure-devops-extension-sdk instead.",
       "dependencies": {


### PR DESCRIPTION
## Summary
Resolves security alerts caused by direct access to npmjs.org.

## Changes
- Added .npmrc at repo root with proxy registry:
  `registry=https://packagefeedproxy.microsoft.io/npm/`
- Updated all package-lock.json resolved URLs from egistry.npmjs.org to packagefeedproxy.microsoft.io/npm (host-only change, identical path structure).

## Verification
Run `npm ci` to verify packages resolve correctly through the proxy.